### PR TITLE
Fixes link to script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Name the file `language_helloworld_yourusername.xx`. e.g., `js_helloworld_mcao.j
 
 Don't forget to include the comments as seen above. Feel free to include additional information about the language you choose in your comments too! Like a link to a helpful introduction or tutorial. 
 
-Here is my `hello_world` example: [js_helloworld_mcao.js](https://github.com/mcao/hacktoberfest/blob/master/scripts/js_helloworld_mcao.js)
+Here is my `hello_world` example: [js_helloworld_mcao.js](https://github.com/alexendrios/hacktoberfest-2019/blob/master/scripts/js_helloworld_mcao.js)
 
 ## BONUS!
 * See profiles submitted by fellow coders from around the globe!


### PR DESCRIPTION
Link to the example script was giving a 404 response. I updated the readme.md to use the appropriate file path.